### PR TITLE
refactor(CitasUser): update cancellation logic to mark appointments a…

### DIFF
--- a/src/components/dashboard-profesional/CitasUser.tsx
+++ b/src/components/dashboard-profesional/CitasUser.tsx
@@ -72,10 +72,8 @@ const CitasUser = () => {
 
         try {
             await appointmentsService.cancelAppointment(id);
-
-            // Actualizar la lista local - eliminar la cita cancelada
-            setCitas((prev) => prev.filter((cita) => cita.id !== id));
-            
+            // Actualizar la lista local - marcar la cita como cancelada
+            setCitas((prev) => prev.map((cita) => cita.id === id ? { ...cita, status: 'cancelled' } : cita));
             notifications.success('Cita cancelada exitosamente.');
         } catch (error) {
             console.error('Error cancelling appointment:', error);


### PR DESCRIPTION
…s cancelled instead of removing them
This pull request updates the way cancelled appointments are handled in the `CitasUser` component. Instead of removing cancelled appointments from the local list, the code now marks them as cancelled, improving visibility and consistency in the user interface.

* Appointment cancellation logic: When an appointment is cancelled, the local state is updated to mark the appointment's `status` as `'cancelled'` instead of removing it from the list. (`src/components/dashboard-profesional/CitasUser.tsx`)