### PR TITLE
Cambio de page a app de OAuth

### DIFF
--- a/src/app/oauth-callback/page.tsx
+++ b/src/app/oauth-callback/page.tsx
@@ -17,7 +17,7 @@ export default function OAuthCallback() {
         if (token) {
           // Guardar token en las cookies del frontend
           Cookies.set('auth_token', token, {
-            expires: 1, // El token expira en 1 día
+            expires: 7, // El token expira en 7 días
             secure: process.env.NODE_ENV === 'production', // Solo HTTPS en producción
             sameSite: 'strict', // Protección CSRF
           });


### PR DESCRIPTION
This pull request makes a small update to the OAuth callback logic by extending the expiration period of the authentication token stored in cookies from 1 day to 7 days. This change will keep users logged in for a longer period before requiring re-authentication.