### PR TITLE
refactor: remove console.log statements

### DIFF
--- a/src/app/session/[slug]/page.tsx
+++ b/src/app/session/[slug]/page.tsx
@@ -326,7 +326,6 @@ const SessionPage = () => {
     // Manejar éxito del pago
     const handlePaymentSuccess = () => {
         setPaymentCompleted(true);
-        // console.log('Pago completado, redirigiendo a MercadoPago...');
         // El componente MercadoPagoPayment ya maneja la redirección automáticamente
     };
 

--- a/src/components/dashboard-profesional/Perfil.tsx
+++ b/src/components/dashboard-profesional/Perfil.tsx
@@ -209,9 +209,6 @@ const Perfil = () => {
                 bodySend = {};
                 setEditable(false);
 
-                console.log('Respuesta completa', response);
-                console.log('imagen', response.data.profile_picture);
-
                 notifications.success(`${response.message}`);
             })
             .catch((error) => {

--- a/src/components/dashboard-profesional/PerfilUser.tsx
+++ b/src/components/dashboard-profesional/PerfilUser.tsx
@@ -203,7 +203,6 @@ const PerfilUser = () => {
                         Authorization: `Bearer ${token}`,
                     },
                 });
-                console.log(res)
                 if (res.status === 401) {
                     router.push('/login');
                     return;

--- a/src/components/register-professional-validation/PhoneField.tsx
+++ b/src/components/register-professional-validation/PhoneField.tsx
@@ -20,7 +20,6 @@ const PhoneField = () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ field: 'phone', phoneValue: `+${value}` }),
           });
-          console.log("Value que mando", value)
           if (res.status === 409) return resolve('El teléfono ya está registrado');
           resolve(undefined);
         } catch {

--- a/src/hooks/useAdminDashboardMetrics.ts
+++ b/src/hooks/useAdminDashboardMetrics.ts
@@ -58,8 +58,6 @@ export function useAdminDashboardMetrics(pollInterval = 8000000) {
                         pageVisitsData = pageVisitsResponse.data || [];
                     }
                 } catch {
-                    // Si el endpoint no existe o falla, generamos datos basados en métricas existentes
-                    // console.log('Endpoint de page visits no disponible, usando datos calculados');
                     pageVisitsData = [
                         { page: 'Dashboard Principal', visits: Math.round(metricsData.users * 0.85) },
                         { page: 'Búsqueda de Psicólogos', visits: Math.round(metricsData.users * 0.72) },

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -5,7 +5,6 @@ const getAuthToken = () => {
     const token = localStorage.getItem('authToken') || 
                   Cookies.get('authToken') || 
                   Cookies.get('auth_token');
-    // console.log('🔑 Token obtenido:', token ? 'Token presente' : 'Token NO encontrado');
     return token;
 };
 


### PR DESCRIPTION
This pull request focuses on cleaning up the codebase by removing unnecessary `console.log` statements from various components and utility files. These changes help improve code readability and maintainability by eliminating leftover debugging output.

Code cleanup:

* Removed multiple `console.log` statements from the `Perfil`, `PerfilUser`, and `PhoneField` components to reduce console noise and improve user-facing code quality. [[1]](diffhunk://#diff-961577310e7f7bffa272d6ce9ef1baf9037f06896174726db442c6f4cb1161c4L212-L214) [[2]](diffhunk://#diff-1e3044c1beea8c8808e46600d015ff2b3d58e0b4b3685f1c7dcea23aacd0bb27L206) [[3]](diffhunk://#diff-9893152c2dcedd40c322ec74726adc36864745030452ae9639182ada2e933d20L23)
* Cleaned up the `SessionPage` and `useAdminDashboardMetrics` logic by removing unused logging related to payment success and fallback metric calculation. ([src/app/session/[slug]/page.tsxL329](diffhunk://#diff-18be39a6490b6d18c74b277e110dd5d557fedac3106d4da5ed44425fcb040fd8L329), [src/hooks/useAdminDashboardMetrics.tsL61-L62](diffhunk://#diff-7ccb7dfa58c26539e2ef9620dc1dbe91c6da62d8ee82be2ad5f1cfed2cde797dL61-L62))
* Removed a debug log from the `getAuthToken` service to prevent leaking token presence information in the console.